### PR TITLE
perf: fix caching of js and css assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/assets/*.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/assets/*.css",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,16 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "headers": [
     {
-      "source": "/assets/*.js",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    },
-    {
-      "source": "/assets/*.css",
+      "source": "/assets/(.*)\\.(js|css)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Trying to use immutable caching headers rather than must-revalidate. 

Surprised tanstack starts vercel deployment integration doesn't do this by default.

Preview confirms this is working:
![image](https://github.com/user-attachments/assets/42ec36b7-3018-40f8-9953-5cbb4e7de9d6)
